### PR TITLE
Fixed issue with illuminate/support 5.3 do not have boot method.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/view": "^5.2",
-        "illuminate/database": "^5.2",
-        "illuminate/events": "^5.2",
-        "illuminate/pagination": "^5.2",
-        "illuminate/http": "^5.2",
-        "recca0120/laravel-tracy": "^1.5"
+        "illuminate/view": "5.2.*",
+        "illuminate/database": "5.2.*",
+        "illuminate/events": "5.2.*",
+        "illuminate/pagination": "5.2.*",
+        "illuminate/http": "5.2.*",
+        "recca0120/laravel-tracy": "1.5.*"
     },
     "require-dev": {
         "nesbot/carbon": "~1.20",


### PR DESCRIPTION
I think this repo should limit dependency to illuminate 5.2 because with 5.3 there is so many error, I found that illuminate support don't have boot method.
